### PR TITLE
feat: add justfile commands for managing Docker services

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # News Letters
+
+## Development
+
+### Requirements
+
+- [docker](https://docs.docker.com/)
+- [just](https://github.com/casey/just)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 services:
   api:
+    container_name: newsletter-api
     build:
       context: ./api
     command: python manage.py runserver 0.0.0.0:8000
@@ -11,6 +12,7 @@ services:
       - db
 
   client:
+    container_name: newsletter-client
     build:
       context: ./client
     volumes:
@@ -21,6 +23,7 @@ services:
       - api 
 
   db:
+    container_name: newsletter-db
     image: postgres:17
     volumes:
       - postgres_data:/var/lib/postgresql/data

--- a/justfile
+++ b/justfile
@@ -1,0 +1,14 @@
+default:
+    @echo "Available commands:"
+    @echo "  just up                - Start all services in detached mode"
+    @echo "  just shell {{service}} - Open a bash shell in the specified service"
+    @echo "  just manage {{*args}}  - Run a manage.py command with the specified arguments in the api service"
+
+up:
+    docker compose up -d
+
+shell service:
+    docker compose exec {{service}} bash
+
+manage *args:
+    docker compose exec api python manage.py {{args}}


### PR DESCRIPTION
## Overview
- Added default task to list available commands.
- Added up command to start all services in detached mode.
- Added shell command to open a bash shell in the specified service.
- Added manage command to run a manage.py command with specified arguments in the api service.
